### PR TITLE
deprecated /plugins_public

### DIFF
--- a/shit.json
+++ b/shit.json
@@ -38,7 +38,7 @@
         "auth": false,
         "endpoint": "https://api.minehut.com/plugins_public",
         "description": [
-            "Returns all available Minehut plugins."
+            "(Deprecated) Returns all available Minehut plugins."
         ],
         "response": {
             "file": "plugins_public.txt"


### PR DESCRIPTION
deprecated the /plugins_public endpoint since it can no longer be used